### PR TITLE
Update chord.cpp

### DIFF
--- a/src/Chord.cpp
+++ b/src/Chord.cpp
@@ -87,7 +87,7 @@ struct Chord : Module {
 	Chord() {
     config(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS);
 
-    configParam(OFFSET_PARAM, 0.0, 1.0, 0.0,"Offset");
+    configParam(OFFSET_PARAM, 0.0, 1.0, 0.5,"Offset");
     configParam(INVERSION_PARAM, 0.0, 1.0, 0.0,"Inversion");
     configParam(VOICING_PARAM, 0.0, 1.0, 0.0,"Voicing");
     configParam(OFFSET_AMT_PARAM, 0.0, 1.0, 0.5,"Offset Amt");


### PR DESCRIPTION
changes the offset initialize value for the offset knob to 0.5 which makes the root note output match the input v/oct, currently it shifts down a half octave by default