### PR TITLE
fix: Bene trigger out doesn't update in real-time

### DIFF
--- a/src/Bene.cpp
+++ b/src/Bene.cpp
@@ -480,8 +480,6 @@ struct Bene : Module {
     if (step_right)
     {
       lights[GRID_LIGHTS + x_position + y_position*4].value=0;
-      if(gates[x_position][y_position])
-        trig_out[x_position][y_position].trigger(1e-3);
       x_position += 1;
       if (x_position > 3)
       {
@@ -497,8 +495,6 @@ struct Bene : Module {
     if (step_left)
     {
       lights[GRID_LIGHTS + x_position + y_position*4].value=0;
-      if(gates[x_position][y_position])
-        trig_out[x_position][y_position].trigger(1e-3);
       x_position -= 1;
       if (x_position < 0)
       {
@@ -514,8 +510,6 @@ struct Bene : Module {
     if (step_down)
     {
       lights[GRID_LIGHTS + x_position + y_position*4].value=0;
-      if(gates[x_position][y_position])
-        trig_out[x_position][y_position].trigger(1e-3);
       y_position += 1;
       if (y_position > 3)
       {
@@ -531,8 +525,6 @@ struct Bene : Module {
     if (step_up)
     {
       lights[GRID_LIGHTS + x_position + y_position*4].value=0;
-      if(gates[x_position][y_position])
-        trig_out[x_position][y_position].trigger(1e-3);
       y_position -= 1;
       if (y_position < 0)
       {
@@ -545,9 +537,6 @@ struct Bene : Module {
       }
       lights[GRID_LIGHTS + x_position + y_position*4].value=1;
     }
-
-    trig[x_position][y_position] = trig_out[x_position][y_position].process(deltaTime);
-    outputs[TRIG_OUT].setVoltage(trig[x_position][y_position]?10.f:0.f);
 
     /// set outputs
 
@@ -566,9 +555,23 @@ struct Bene : Module {
     outputs[COLUMN_OUT + i].value = column_outs[i];
   }
   
-  
   outputs[QUANT_OUT].setVoltage(quant_out);
+
   outputs[GATE_OUT].setVoltage(gates[x_position][y_position] ? 10.f : 0.f);
+
+//outputs a trigger using gates[] and step conditions.
+
+  if(gates[x_position][y_position])
+
+    if (step_up or step_down or step_left or step_right)
+
+      trig_out[x_position][y_position].trigger(1e-3);
+
+
+  trig[x_position][y_position] = trig_out[x_position][y_position].process(deltaTime);
+
+  outputs[TRIG_OUT].setVoltage(trig[x_position][y_position]?10.f:0.f);
+
 
   if(rightExpander.module && rightExpander.module->model == modelBenePads) 
   {

--- a/src/Bene.cpp
+++ b/src/Bene.cpp
@@ -191,6 +191,10 @@ struct Bene : Module {
           configButton(Y_DIR_PARAM ,"Direction Y");
           configButton(X_LOCK_PARAM,"Lock X");
           configButton(Y_LOCK_PARAM,"Lock Y");
+	    
+	  configOutput(GATE_OUT, "Gate");
+          configOutput(QUANT_OUT, "V/Oct");
+          configOutput(TRIG_OUT, "Trigger");
 
         rightExpander.producerMessage = producerMessage;
 		    rightExpander.consumerMessage = consumerMessage;

--- a/src/PerfMixer.cpp
+++ b/src/PerfMixer.cpp
@@ -110,8 +110,8 @@ struct PerfMixer : Module {
     configParam(MAIN_VOL_PARAM,  0.0, 1.0, 0.5,"Mix Level", "%", 0, 100);
     configParam(AUX_R1_PARAM,  0.0, 1.0, 0.0,"Aux Return 1", "%", 0, 100);
     configParam(AUX_R2_PARAM,  0.0, 1.0, 0.0,"Aux Return 2", "%", 0, 100);
-    configParam(AUX_S1_PARAM,  0.0, 1.0, 0.0,"Auz Send 1", "%", 0, 100);
-    configParam(AUX_S2_PARAM,  0.0, 1.0, 0.0,"Auz Send 2", "%", 0, 100);
+    configParam(AUX_S1_PARAM,  0.0, 1.0, 0.0,"Aux Send 1", "%", 0, 100);
+    configParam(AUX_S2_PARAM,  0.0, 1.0, 0.0,"Aux Send 2", "%", 0, 100);
 
     for(int i=0;i<8;i++)
     {

--- a/src/PerfMixer4.cpp
+++ b/src/PerfMixer4.cpp
@@ -105,8 +105,8 @@ struct PerfMixer4 : Module {
     configParam(MAIN_VOL_PARAM,  0.0, 1.0, 0.5,"Mix Level", "%", 0, 100);
     configParam(AUX_R1_PARAM,  0.0, 1.0, 0.0,"Aux Return 1", "%", 0, 100);
     configParam(AUX_R2_PARAM,  0.0, 1.0, 0.0,"Aux Return 2", "%", 0, 100);
-    configParam(AUX_S1_PARAM,  0.0, 1.0, 0.0,"Auz Send 1", "%", 0, 100);
-    configParam(AUX_S2_PARAM,  0.0, 1.0, 0.0,"Auz Send 2", "%", 0, 100);
+    configParam(AUX_S1_PARAM,  0.0, 1.0, 0.0,"Aux Send 1", "%", 0, 100);
+    configParam(AUX_S2_PARAM,  0.0, 1.0, 0.0,"Aux Send 2", "%", 0, 100);
 
     for(int i=0;i<4;i++)
     {


### PR DESCRIPTION
BENE:
Bene's trigger output doesn't follow sequencer tweaks in real-time. It won't always "update" with step positions as they're edited.
I moved the trig_out.trigger() from the if(step) calls and placed it in the same scope as the other outputs. It's been placed in a logic statement that checks the gates[] array for each current x_pos and y_pos, and runs the trig_out every time a step variable is made true. 
Sequences can now be edited mid-cycle, without Bene skipping notes that were added mid-playthrough or playing disabled steps.

PerfMixer/PerfMixer4: 
Fixed a typo which spelled "Aux send" as "Auz send"